### PR TITLE
Implement PX4 Manual Control Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /__pycache__/
 prompt.txt
 issue.md
+/mavlink-env
+/gh_2.92.0_linux_amd64
+gh_2.92.0_linux_amd64.tar.gz

--- a/mavlink_driver.py
+++ b/mavlink_driver.py
@@ -53,7 +53,9 @@ def _load_mpc_module():
 
 # ====================== USER PARAMETERS (EDIT HERE) ====================
 # MAVLink
-MAVLINK_URL  = "udp:172.24.32.1:14550"
+MAVLINK_URL  = "udp:0.0.0.0:14580"
+# Autopilot type: "ardupilot" | "px4"
+AUTOPILOT_TYPE = "px4"
 
 # Mode: "l1" (capture only), "mpc" (tracker only), "blend" (L1→MPC with gating+easing)
 LATERAL_MODE = "blend"
@@ -143,6 +145,17 @@ def _wrap(a: float) -> float: return math.atan2(math.sin(a), math.cos(a))
 def _smoothstep(x: float) -> float:
     x = max(0.0, min(1.0, x)); return x*x*(3.0 - 2.0*x)
 
+def euler_to_quaternion(roll, pitch, yaw):
+    cr = math.cos(roll * 0.5); sr = math.sin(roll * 0.5)
+    cp = math.cos(pitch * 0.5); sp = math.sin(pitch * 0.5)
+    cy = math.cos(yaw * 0.5); sy = math.sin(yaw * 0.5)
+    return [
+        cr * cp * cy + sr * sp * sy,
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy
+    ]
+
 def orbit_metrics(n, e, chi, C, R, ccw=True):
     r = np.array([n, e]) - np.asarray(C, float)
     rho = float(np.linalg.norm(r)) + 1e-9
@@ -180,14 +193,39 @@ def roll_deg_to_pwm_linear(roll_deg: float) -> int:
     return min(PWM_MAX, max(PWM_MIN, pwm))
 
 def connect_mavlink(url: str) -> mavutil.mavfile:
-    m = mavutil.mavlink_connection(url, autoreconnect=True, dialect="ardupilotmega")
+    dialect = "ardupilotmega" if AUTOPILOT_TYPE == "ardupilot" else "common"
+    m = mavutil.mavlink_connection(url, autoreconnect=True, dialect=dialect)
     m.wait_heartbeat(timeout=30)
     print(f"[MAV] Heartbeat ok (sys={m.target_system} comp={m.target_component})")
     return m
 
 _PLANE_MODES = {0:"MANUAL",1:"CIRCLE",2:"STABILIZE",5:"FBWA",6:"FBWB",7:"CRUISE",10:"AUTO",11:"RTL",12:"LOITER",15:"GUIDED"}
 def decode_plane_mode(custom_mode: int) -> str: return _PLANE_MODES.get(int(custom_mode), f"MODE_{custom_mode}")
+
+_PX4_MAIN_MODES = {1:"MANUAL", 2:"ALTCTL", 3:"POSCTL", 4:"AUTO", 5:"ACRO", 6:"OFFBOARD", 7:"STABILIZED", 8:"RATTITUDE"}
+_PX4_SUB_MODES = {1:"READY", 2:"TAKEOFF", 3:"LOITER", 4:"MISSION", 5:"RTL", 6:"LAND"}
+
+def decode_px4_mode(custom_mode: int) -> str:
+    main_mode = (custom_mode >> 16) & 0xFF
+    sub_mode  = (custom_mode >> 24) & 0xFF
+    m_name = _PX4_MAIN_MODES.get(main_mode, f"MAIN_{main_mode}")
+    if main_mode == 4: # AUTO
+        s_name = _PX4_SUB_MODES.get(sub_mode, f"SUB_{sub_mode}")
+        return f"AUTO_{s_name}"
+    return m_name
+
 def set_mode(m: mavutil.mavfile, name: str) -> None:
+    if AUTOPILOT_TYPE == "px4":
+        if name.upper() == "OFFBOARD":
+            # PX4 OFFBOARD: main_mode=6, sub_mode=0
+            m.mav.command_long_send(m.target_system, m.target_component,
+                                    mavutil.mavlink.MAV_CMD_DO_SET_MODE, 0,
+                                    mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+                                    6, 0, 0, 0, 0, 0)
+        else:
+            print(f"[MAV] PX4 set_mode '{name}' not specifically implemented, skipping.")
+        return
+
     try: m.set_mode_apm(name)
     except Exception:
         m.mav.command_long_send(m.target_system, m.target_component,
@@ -249,7 +287,11 @@ def state_reader(m: mavutil.mavfile, S: Shared):
         with S.state_lock:
             st = S.state
             if tname=="HEARTBEAT":
-                try: st.mode = decode_plane_mode(msg.custom_mode)
+                try:
+                    if AUTOPILOT_TYPE == "px4":
+                        st.mode = decode_px4_mode(msg.custom_mode)
+                    else:
+                        st.mode = decode_plane_mode(msg.custom_mode)
                 except Exception: pass
                 st.ts = tnow
             elif tname=="LOCAL_POSITION_NED":
@@ -472,7 +514,10 @@ def att_sender(m: mavutil.mavfile, S: Shared, hz: float=TX_HZ):
     period = 1.0 / max(1e-3, hz)
     next_t=time.monotonic(); t0=time.monotonic(); cnt=0
     try:
-        set_mode(m, "FBWB")
+        if AUTOPILOT_TYPE == "px4":
+            set_mode(m, "OFFBOARD")
+        else:
+            set_mode(m, "FBWB")
     except Exception:
         pass
     while not S.stop.is_set():
@@ -480,12 +525,26 @@ def att_sender(m: mavutil.mavfile, S: Shared, hz: float=TX_HZ):
         with S.cmd_lock: roll_cmd = float(S.cmd_roll)
         with S.state_lock: st = NavState(**vars(S.state))
         if (time.monotonic()-st.ts) > STALE_TIMEOUT: continue
-        # mapping linear dari BANK_LIMIT_DEG → PWM (tanpa shaping tambahan)
-        pwm = roll_deg_to_pwm_linear(math.degrees(roll_cmd))       
-        m.mav.rc_channels_override_send(
-            m.target_system, m.target_component,
-            pwm, 1500, 1550, 0, 0, 0, 0, 0     
-        )
+
+        if AUTOPILOT_TYPE == "px4":
+            # PX4 OFFBOARD: Use SET_ATTITUDE_TARGET
+            q = euler_to_quaternion(roll_cmd, st.pitch, st.yaw)
+            # type_mask=7: ignore body rates, use quaternion + thrust
+            m.mav.set_attitude_target_send(
+                int((time.monotonic()-BOOT_T0)*1000),
+                m.target_system, m.target_component,
+                7,
+                q,
+                0, 0, 0,
+                st.throttle if st.throttle > 0.01 else 0.5 # fallback thrust 50%
+            )
+        else:
+            # ArduPilot: mapping linear dari BANK_LIMIT_DEG → PWM
+            pwm = roll_deg_to_pwm_linear(math.degrees(roll_cmd))
+            m.mav.rc_channels_override_send(
+                m.target_system, m.target_component,
+                pwm, 1500, 1550, 0, 0, 0, 0, 0
+            )
         if (time.monotonic()-t0)>=1.0:
             S.hz_tx = cnt / (time.monotonic()-t0); t0=time.monotonic(); cnt=0
 

--- a/mavlink_driver.py
+++ b/mavlink_driver.py
@@ -53,7 +53,7 @@ def _load_mpc_module():
 
 # ====================== USER PARAMETERS (EDIT HERE) ====================
 # MAVLink
-MAVLINK_URL  = "udp:0.0.0.0:14580"
+MAVLINK_URL  = "udp:0.0.0.0:14540"
 # Autopilot type: "ardupilot" | "px4"
 AUTOPILOT_TYPE = "px4"
 
@@ -192,6 +192,12 @@ def roll_deg_to_pwm_linear(roll_deg: float) -> int:
     pwm = int(round(PWM_TRIM + k * roll_deg))
     return min(PWM_MAX, max(PWM_MIN, pwm))
 
+def roll_deg_to_manual_y(roll_deg: float) -> int:
+    # map -BANK_LIMIT_DEG..BANK_LIMIT_DEG to -1000..1000 (standard for MANUAL_CONTROL)
+    roll_deg = max(-BANK_LIMIT_DEG, min(BANK_LIMIT_DEG, roll_deg))
+    val = int(round((roll_deg / max(1.0, BANK_LIMIT_DEG)) * 1000))
+    return max(-1000, min(1000, val))
+
 def connect_mavlink(url: str) -> mavutil.mavfile:
     dialect = "ardupilotmega" if AUTOPILOT_TYPE == "ardupilot" else "common"
     m = mavutil.mavlink_connection(url, autoreconnect=True, dialect=dialect)
@@ -222,6 +228,12 @@ def set_mode(m: mavutil.mavfile, name: str) -> None:
                                     mavutil.mavlink.MAV_CMD_DO_SET_MODE, 0,
                                     mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
                                     6, 0, 0, 0, 0, 0)
+        elif name.upper() == "ALTITUDE":
+            # PX4 ALTITUDE: main_mode=2, sub_mode=0
+            m.mav.command_long_send(m.target_system, m.target_component,
+                                    mavutil.mavlink.MAV_CMD_DO_SET_MODE, 0,
+                                    mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+                                    2, 0, 0, 0, 0, 0)
         else:
             print(f"[MAV] PX4 set_mode '{name}' not specifically implemented, skipping.")
         return
@@ -515,7 +527,7 @@ def att_sender(m: mavutil.mavfile, S: Shared, hz: float=TX_HZ):
     next_t=time.monotonic(); t0=time.monotonic(); cnt=0
     try:
         if AUTOPILOT_TYPE == "px4":
-            set_mode(m, "OFFBOARD")
+            set_mode(m, "ALTITUDE")
         else:
             set_mode(m, "FBWB")
     except Exception:
@@ -526,25 +538,17 @@ def att_sender(m: mavutil.mavfile, S: Shared, hz: float=TX_HZ):
         with S.state_lock: st = NavState(**vars(S.state))
         if (time.monotonic()-st.ts) > STALE_TIMEOUT: continue
 
-        if AUTOPILOT_TYPE == "px4":
-            # PX4 OFFBOARD: Use SET_ATTITUDE_TARGET
-            q = euler_to_quaternion(roll_cmd, st.pitch, st.yaw)
-            # type_mask=7: ignore body rates, use quaternion + thrust
-            m.mav.set_attitude_target_send(
-                int((time.monotonic()-BOOT_T0)*1000),
-                m.target_system, m.target_component,
-                7,
-                q,
-                0, 0, 0,
-                st.throttle if st.throttle > 0.01 else 0.5 # fallback thrust 50%
-            )
-        else:
-            # ArduPilot: mapping linear dari BANK_LIMIT_DEG → PWM
-            pwm = roll_deg_to_pwm_linear(math.degrees(roll_cmd))
-            m.mav.rc_channels_override_send(
-                m.target_system, m.target_component,
-                pwm, 1500, 1550, 0, 0, 0, 0, 0
-            )
+        # mapping linear dari BANK_LIMIT_DEG → MANUAL_CONTROL (-1000..1000)
+        # Ini dianggap valid pilot input oleh PX4 (lebih reliable dibanding RC override)
+        roll_val = roll_deg_to_manual_y(math.degrees(roll_cmd))
+        m.mav.manual_control_send(
+            m.target_system,
+            0,          # x (pitch)
+            roll_val,   # y (roll)
+            500,        # z (throttle, 0–1000)
+            0,          # r (yaw)
+            0           # buttons
+        )
         if (time.monotonic()-t0)>=1.0:
             S.hz_tx = cnt / (time.monotonic()-t0); t0=time.monotonic(); cnt=0
 


### PR DESCRIPTION
Closes #2. This PR implements PX4 manual control in mavlink_driver to provide more reliable control for PX4-based UAVs, replacing RC override.